### PR TITLE
create dataset returns train, val and test set

### DIFF
--- a/pix2pix/dataset.py
+++ b/pix2pix/dataset.py
@@ -4,6 +4,7 @@ from torch.utils.data import Dataset
 from PIL import Image
 import numpy as np
 import math
+import os
 
 
 class Pix2PixDataset(Dataset):

--- a/pix2pix/utilities.py
+++ b/pix2pix/utilities.py
@@ -165,6 +165,9 @@ def train_val_test_split(data: list, split_percent: float, shuffle=True):
     train = data[: split1]
     val = data[split1: split1 + split2]
     test = data[split1 + split2: (split1 + (split2 * 2))]
+    if len(val) == 0 or len(test) == 0:
+        raise ValueError('Not enough data for train/val/test split.\n'
+                         'Try a lower split_percent')
     return train, val, test
 
 

--- a/train_model.py
+++ b/train_model.py
@@ -32,13 +32,9 @@ L1_LAMBDA = 100
 
 
 def main():
-    # get files from dataset
-    files = utils.get_files(DATASET_PATH, include_correlated=False)
-
-    # create train, val, test sets
-    train, _, _, = utils.train_val_test_split(files, 0.8)
-
-    train_dataset = Pix2PixDataset(train, augment=False)
+    train_path = '/Users/anthonygavriel/Dissertation/code/data/train'
+    train_dataset = Pix2PixDataset(train_path, augment=False)
+    print(train_dataset.__getitem__(0))
 
     train_loader = DataLoader(train_dataset,
                               batch_size=BATCH_SIZE,


### PR DESCRIPTION
Had to reconfigure the create dataset pipeline
- A link to recordings in the raw data folder are made rather than copies
- These links are paired and stored in tuples
- They are then split into train/val/test sets
- Each set is passed to `generate_data()` which creates spectrograms for the pairs and stitches them together in memory
- The stitched image is saved

This causes a significant improvement time and memory when generating the dataset